### PR TITLE
Added period at end of line 19 ReactComponent.js

### DIFF
--- a/src/core/ReactNativeComponent.js
+++ b/src/core/ReactNativeComponent.js
@@ -16,7 +16,7 @@ var invariant = require('invariant');
 
 var autoGenerateWrapperClass = null;
 var genericComponentClass = null;
-// This registry keeps track of wrapper classes around native tags
+// This registry keeps track of wrapper classes around native tags.
 var tagToComponentClass = {};
 var textComponentClass = null;
 


### PR DESCRIPTION
Corrected formatting error for line 19 of ReactComponent.js by adding a period in order to be consistent with the other comments in the file.
